### PR TITLE
Fix sdist packaging for v1.5.46

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE CHANGES README.rst requirements.txt ciscoconfparse/version.json
+include LICENSE CHANGES README.rst requirements.txt ciscoconfparse/metadata.json
 recursive-exclude * __pycache__
 recursive-exclude * *.pyc
 recursive-exclude * *.pyo


### PR DESCRIPTION
When building the sdist tarball (distributed via PyPI), the following error message appears multiple times:

2021-08-25_12:30:13.129 | WARNING  | name:get_metadata:87 - An error has been caught in function 'get_metadata', process 'MainProcess' 
(44598), thread 'MainThread' (34395480064):

Remedy this issue by adding "ciscoconfparse/metadata.json" to "MANIFEST.in".  Also remove "ciscoconfparse/version.json" there as the latter one doesn't seem to exist in the repository anymore.